### PR TITLE
Fix bug casting properties

### DIFF
--- a/ios/Classes/SwiftFlutuateMixpanelPlugin.swift
+++ b/ios/Classes/SwiftFlutuateMixpanelPlugin.swift
@@ -76,7 +76,7 @@ public class SwiftFlutuateMixpanelPlugin: NSObject, FlutterPlugin {
   private func track(call: FlutterMethodCall, result: @escaping FlutterResult) {
     let arguments = call.arguments as? [String:Any]
     let eventName = arguments?["eventName"] as? String
-    let properties = arguments?["properties"] as? Properties
+    let properties = arguments?["properties"] as? [String:String]
 	Mixpanel.mainInstance().track( event: eventName, properties: properties);
   }
   


### PR DESCRIPTION
on iOS I can't get my properties if It casts using "Properties". If I used [String:String] it works fine. Please try it.